### PR TITLE
Maint/require vehicle cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,21 @@ python3 setup.py install --user
 
 ## Usage
 
-`oscc-check.py [-hdelv] [-b <bustype>] [-c <channel>] [-V <vehicle>]`
+`oscc-check.py (-V <vehicle>) [-hdelv] [-b <bustype>] [-c <channel>]`
 
 ### Options
 
 ```bash
 Options:
     -h --help                            Display this information
+    -V <vehicle>, --vehicle <vehicle>    Specify your vehicle. Required.
+                                         (kia_soul_ev / kia_soul_petrol / kia_niro)
     -d --disable                         Disable modules only, no further checks (overrides enable)
     -e --enable                          Enable modules only, no further checks checks
     -l --loop                            Repeat all checks, run continuously
     -b --bustype <bustype>               CAN bus type [default: socketcan_native]
                                          (for more see https://python-can.readthedocs.io/en/2.1.0/interfaces.html)
     -c <channel>, --channel <channel>    Specify CAN channel, [default: can0]
-    -V <vehicle>, --vehicle <vehicle>    Specify your vehicle, [default: kia_soul_ev]
-                                         (kia_soul_ev / kia_soul_petrol / kia_niro)
     -v --version                         Display version information
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ for `bustype` and `channel`. After initializing the socketcan interface with:
 you can run:
 
 ```bash
-# Default Linux usage
-python3 oscc-check.py
+# Default Linux usage for Kia Soul EV
+python3 oscc-check.py -V kia_soul_ev
 ```
 
 #### Windows
@@ -135,15 +135,15 @@ On a Windows system `socketcan` is not available so the `bustype` and `channel` 
 If you've installed the Kvaser SDK you need to run:
 
 ```bash
-# Default Kvaser CANlib usage
-python oscc-check.py -c 0 -b kvaser
+# Default Kvaser CANlib usage for Kia Soul Petrol
+python oscc-check.py -c 0 -b kvaser -V kia_soul_petrol
 ```
 
 Using PCAN drivers you can run:
 
 ```bash
-# Default PEAK PCAN-USB usage
-python oscc-check.py -c PCAN_USBBUS1 -b pcan
+# Default PEAK PCAN-USB usage for Kia Niro
+python oscc-check.py -c PCAN_USBBUS1 -b pcan -V kia_niro
 ```
 
 # License

--- a/oscc-check.py
+++ b/oscc-check.py
@@ -1,16 +1,16 @@
 #!/usr/bin/python3
-"""Usage: oscc-check.py [-hdelv] [-b <bustype>] [-c <channel>] [-V <vehicle>]
+"""Usage: oscc-check.py (-V <vehicle>) [-hdelv] [-b <bustype>] [-c <channel>]
 
 Options:
     -h --help                            Display this information
+    -V <vehicle>, --vehicle <vehicle>    Specify your vehicle. Required.
+                                         (kia_soul_ev / kia_soul_petrol / kia_niro)
     -d --disable                         Disable modules only, no further checks (overrides enable)
     -e --enable                          Enable modules only, no further checks checks
     -l --loop                            Repeat all checks, run continuously
     -b --bustype <bustype>               CAN bus type [default: socketcan_native]
                                          (for more see https://python-can.readthedocs.io/en/2.1.0/interfaces.html)
     -c <channel>, --channel <channel>    Specify CAN channel, [default: can0]
-    -V <vehicle>, --vehicle <vehicle>    Specify your vehicle, [default: kia_soul_ev]
-                                         (kia_soul_ev / kia_soul_petrol / kia_niro)
     -v --version                         Display version information
 """
 
@@ -350,9 +350,9 @@ def main(args):
     check_vehicle_arg(args['--vehicle'])
 
     bus = CanBus(
+        vehicle=args['--vehicle'],
         bustype=args['--bustype'],
-        channel=args['--channel'],
-        vehicle=args['--vehicle'])
+        channel=args['--channel'])
 
     brakes = OsccModule(base_arbitration_id=0x70, module_name='brake')
     steering = OsccModule(base_arbitration_id=0x80, module_name='steering')

--- a/oscccan/canbus.py
+++ b/oscccan/canbus.py
@@ -29,10 +29,10 @@ class CanBus(object):
     """
     def __init__(
         self,
+        vehicle,
         bustype='socketcan_native',
         channel='can0',
-        bitrate=500000,
-        vehicle='kia_soul_ev'):
+        bitrate=500000):
         """
         Connect to CAN bus.
         """


### PR DESCRIPTION
Prior to this commit the vehicle option defaulted to Kia Soul EV which
had the potential to hide misconfigurations. This commit makes the vehicle
CLI optioin mandatory.