### PR TITLE
Add initial property tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Using PCAN drivers you can run:
 python oscc-check.py -c PCAN_USBBUS1 -b pcan -V kia_niro
 ```
 
+### Running Tests
+
+`python3 setup.py test`
+
 # License
 
 © 2018, PolySync Technologies, Inc., Shea Newton <snewton@polysync.io>

--- a/oscc-check.py
+++ b/oscc-check.py
@@ -137,7 +137,7 @@ class DebugModules(object):
         # frame to OSCC/DriveKit over its CAN gateway.
         self.bus.disable_module(module)
 
-        time.sleep(1)
+        self.bus.reading_sleep()
 
         # Verify the module parameter is disabled by listening to the OSCC/DriveKit CAN gateway for
         # a status message that confirms it. Set the `success` flag so we can report and handle
@@ -435,5 +435,4 @@ if __name__ == "__main__":
     """
     The program's entry point if run as an executable.
     """
-
     main(docopt(__doc__))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,27 @@
-from setuptools import setup, find_packages
+
 import sys
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
 long_description = open('README.md', 'r').read()
+
+
+class PyTest(TestCommand):
+    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = ""
+
+    def run_tests(self):
+        import shlex
+
+        # import here, cause outside the eggs aren't loaded
+        import pytest
+
+        errno = pytest.main(shlex.split(self.pytest_args))
+        sys.exit(errno)
+
 
 setup(name='oscc-check',
       version='0.0.1',
@@ -20,6 +40,9 @@ setup(name='oscc-check',
           'docopt',
           'python-can',
       ],
+      tests_require=['pytest', 'hypothesis'],
+      test_suite="tests",
+      cmdclass={"test": PyTest},
       classifiers=[
           'Environment :: Console',
           'License :: MIT License',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""
+Test CLI Tooling Module
+"""
+
+from docopt import docopt
+import itertools
+import os
+import subprocess
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "*", "oscc-check.py")
+
+oscc_check = importlib.util.module_from_spec(spec)
+
+spec.loader.exec_module(oscc_check)
+
+
+class CLI(object):
+    """
+    CLI Tooling Class.
+    """
+
+    @staticmethod
+    def valid_flags():
+        return [
+            ['-V'],
+            ['-c'],
+            ['-b'],
+            ['-h'],
+            ['-d'],
+            ['-e'],
+            ['-l'],
+            ['-v'],
+            [''],
+        ]
+
+    @staticmethod
+    def valid_combinatons():
+        return [
+            ['-V', 'kia_soul_ev'],
+            ['-V', 'kia_soul_petrol'],
+            ['-V', 'kia_niro'],
+            ['-c', 'can0'],
+            ['-c', 'can1'],
+            ['-c', '0'],
+            ['-c', 'PCAN_USBBUS1'],
+            ['-b', 'kvaser'],
+            ['-b', 'socketcan'],
+            ['-b', 'pcan'],
+            ['-h'],
+            ['-d'],
+            ['-e'],
+            ['-l'],
+            ['-v'],
+        ]
+
+    @staticmethod
+    def required_flags():
+        return [
+            ['-V', 'kia_soul_ev'],
+            ['-V', 'kia_soul_petrol'],
+            ['-V', 'kia_niro'],
+        ]
+
+    @staticmethod
+    def valid_options():
+        return [
+            ['-c', 'can0'],
+            ['-c', 'can0'],
+            ['-c', 'can1'],
+            ['-c', '0'],
+            ['-c', 'PCAN_USBBUS1'],
+            ['-b', 'kvaser'],
+            ['-b', 'socketcan'],
+            ['-b', 'pcan'],
+            ['-d'],
+            ['-e'],
+            # Don't allow tests to loop indefinitely
+            # ['-l'],
+        ]
+
+    @staticmethod
+    def run(args=['']):
+        if not isinstance(args, list):
+            return False
+
+        flat_args = [item for sublist in args for item in sublist]
+
+        ret = False
+        try:
+            ret = docopt(oscc_check.__doc__, argv=flat_args)
+        except SystemExit as e:
+            # Bad args should cause exit with usage statement (first line of doc string).
+            if str(e) == oscc_check.__doc__.split('\n', 1)[0]:
+                ret = True
+            # Successful `-h` flag raises SystemExit with no error.
+            elif str(e) == '':
+                ret = True
+            else:
+                ret = False
+
+        return ret

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,6 +46,8 @@ class CLI(object):
             ['-c', 'can0'],
             ['-c', 'can1'],
             ['-c', '0'],
+            ['-c', '1'],
+            ['-c', 'PCAN_USBBUS0'],
             ['-c', 'PCAN_USBBUS1'],
             ['-b', 'kvaser'],
             ['-b', 'socketcan'],
@@ -69,9 +71,10 @@ class CLI(object):
     def valid_options():
         return [
             ['-c', 'can0'],
-            ['-c', 'can0'],
             ['-c', 'can1'],
             ['-c', '0'],
+            ['-c', '1'],
+            ['-c', 'PCAN_USBBUS0'],
             ['-c', 'PCAN_USBBUS1'],
             ['-b', 'kvaser'],
             ['-b', 'socketcan'],

--- a/tests/mock_canbus.py
+++ b/tests/mock_canbus.py
@@ -1,0 +1,82 @@
+from oscccan.canbus import Report
+
+
+class CanBus(object):
+    """
+    Mocked CanBus class for tests that don't require harware in loop.
+    """
+
+    def report_success(self, increase_from=None, decrease_from=None):
+        value = 0x01
+
+        if increase_from is not None:
+            value += increase_from
+        elif decrease_from is not None:
+            value -= decrease_from
+
+        return Report(success=True, value=value)
+
+    def __init__(
+            self,
+            vehicle,
+            bustype='socketcan_native',
+            channel='can0',
+            bitrate=500000):
+        pass
+
+    def reading_sleep(self, duration=1.0):
+        pass
+
+    def bus_send_msg(self, arbitration_id, data=None, timeout=1.0):
+        pass
+
+    def enable_module(self, module, timeout=None):
+        pass
+
+    def disable_module(self, module, timeout=None):
+        pass
+
+    def check_module_enabled_status(
+            self,
+            module,
+            timeout=1.0,
+            expect=False):
+        return True
+
+    def send_command(
+            self,
+            module,
+            value,
+            timeout=None):
+        pass
+
+    def recv_report(
+            self,
+            module=None,
+            can_ids=None,
+            timeout=1.0):
+        pass
+
+    def check_brake_pressure(
+            self,
+            increase_from=None,
+            decrease_from=None,
+            timeout=2.0,):
+        return self.report_success(increase_from=increase_from,
+                                   decrease_from=decrease_from)
+
+    def check_steering_wheel_angle(
+            self,
+            increase_from=None,
+            decrease_from=None,
+            timeout=2.0):
+        return self.report_success(increase_from=increase_from,
+                                   decrease_from=decrease_from)
+
+    def get_wheel_speed(self, data, offset):
+        pass
+
+    def check_wheel_speed(
+            self,
+            timeout=2.0):
+        return self.report_success()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+"""
+Test CLI Tooling Module.
+"""
+
+from hypothesis import given, HealthCheck, reject, settings
+from hypothesis.strategies import (
+    integers, lists, randoms, text, sampled_from, characters, composite)
+
+from tests import CLI, oscc_check
+
+random_args = text(characters(max_codepoint=1000, blacklist_categories=(
+    'Cc', 'Cs')), min_size=1).map(lambda s: s.strip()).filter(lambda s: len(s) > 0)
+
+
+@composite
+def flagged_args(draw):
+    flag = draw(sampled_from(CLI.valid_flags()))
+    arg = draw(random_args)
+    return [flag, arg]
+
+
+@given(lists(random_args))
+def test_random_args(args):
+    assert CLI.run(args=args)
+
+
+@given(flagged_args())
+def test_valid_flags_random_args(args):
+    assert CLI.run(args=args)
+
+
+@given(lists(sampled_from(CLI.valid_combinatons())))
+def test_valid_flags_valid_args(args):
+    assert CLI.run(args=args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+"""
+Test oscc-check 'main' function.
+"""
+
+import itertools
+import oscccan
+import unittest
+
+from docopt import docopt
+
+from hypothesis import given, HealthCheck, reject, settings
+from hypothesis.strategies import (
+    integers, lists, randoms, text, sampled_from, characters, composite)
+
+from tests import CLI, oscc_check, mock_canbus
+
+
+class Main(unittest.TestCase):
+    """
+    Mocked oscc-check.py main().
+    """
+
+    def run(self, args=['']):
+        if not isinstance(args, list):
+            return False
+
+        flat_args = [item for sublist in args for item in sublist]
+
+        ret = True
+        try:
+            oscc_check.main(docopt(oscc_check.__doc__, argv=flat_args))
+        except:
+            ret = False
+
+        return ret
+
+
+@composite
+def runtime_args(draw):
+    vehicle = draw(sampled_from(CLI.required_flags()))
+    options = draw(sampled_from(CLI.valid_options()))
+    return [vehicle, options]
+
+
+@settings(max_examples=25)
+@given(runtime_args())
+def test_valid_flags_valid_args(args):
+    oscc_check.CanBus = mock_canbus.CanBus
+    main = Main()
+    assert main.run(args=args)


### PR DESCRIPTION
Prior to this commit, this tool was used for testing and validation but it did not have its own tests. This resulted in the potential for unexplored scenarios to cause the tool to break or act unexpectedly. This commit adds property tests that explore the space of CLI argument combinations, valid and invalid, and asserts that the program reports success and failure as expected.