### PR TITLE
Typo correction in Readme and Docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options:
     -V <vehicle>, --vehicle <vehicle>    Specify your vehicle. Required.
                                          (kia_soul_ev / kia_soul_petrol / kia_niro)
     -d --disable                         Disable modules only, no further checks (overrides enable)
-    -e --enable                          Enable modules only, no further checks checks
+    -e --enable                          Enable modules only, no further checks
     -l --loop                            Repeat all checks, run continuously
     -b --bustype <bustype>               CAN bus type [default: socketcan_native]
                                          (for more see https://python-can.readthedocs.io/en/2.1.0/interfaces.html)

--- a/oscc-check.py
+++ b/oscc-check.py
@@ -6,7 +6,7 @@ Options:
     -V <vehicle>, --vehicle <vehicle>    Specify your vehicle. Required.
                                          (kia_soul_ev / kia_soul_petrol / kia_niro)
     -d --disable                         Disable modules only, no further checks (overrides enable)
-    -e --enable                          Enable modules only, no further checks checks
+    -e --enable                          Enable modules only, no further checks
     -l --loop                            Repeat all checks, run continuously
     -b --bustype <bustype>               CAN bus type [default: socketcan_native]
                                          (for more see https://python-can.readthedocs.io/en/2.1.0/interfaces.html)


### PR DESCRIPTION
Prior to this commit when you entered -h the docstring it output included a typo on line 4 in the help message for the -e option where checks was repeated twice.
I edited out the additional word in the dosctring as well as in the readme file that shows the docstring so that the additional word is not there.
This results in a message that is in proper and correct English.